### PR TITLE
Updating packages on start-up

### DIFF
--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -1,14 +1,20 @@
-FROM php:5.6.17-apache
+FROM php:5.6.31-apache
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
+
+#add dependent packages
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
+RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
+RUN rm /tmp/jessie-backports.list
+
+#install libssl
+RUN apt-get update && apt-get install -y -t jessie-backports libssl1.0.0
 
 #install packages 
 RUN apt-get update && apt-get install -y \
         cron \
         libjpeg62-turbo-dev \
         libpng12-dev \
-        libssl1.0.0 \
-        openssl \
         mysql-client \
         nano \
         python \
@@ -18,9 +24,6 @@ RUN apt-get update && apt-get install -y \
         wget \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
-
-#upgrade old packages
-RUN apt-get upgrade -y
 
 #configure server
 RUN docker-php-ext-install mysqli \

--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -2,18 +2,10 @@ FROM php:5.6.31-apache
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
-#add dependent packages
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
-RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
-RUN rm /tmp/jessie-backports.list
-
-#install libssl and openssl
-RUN apt-get update && apt-get install -y -t jessie-backports \
-        libssl1.0.0 \
-        openssl
-
 #install packages 
-RUN apt-get update && apt-get install -y \
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y \
         cron \
         libjpeg62-turbo-dev \
         libpng12-dev \
@@ -24,6 +16,7 @@ RUN apt-get update && apt-get install -y \
         supervisor \
         vim-tiny \
         wget \
+    && apt-get install -y -t jessie-backports openssl \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
 

--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install -y \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
 
+#upgrade old packages
+RUN apt-get upgrade -y
+
 #configure server
 RUN docker-php-ext-install mysqli \
     && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \

--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -7,8 +7,10 @@ RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-b
 RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
 RUN rm /tmp/jessie-backports.list
 
-#install libssl
-RUN apt-get update && apt-get install -y -t jessie-backports libssl1.0.0
+#install libssl and openssl
+RUN apt-get update && apt-get install -y -t jessie-backports \
+        libssl1.0.0 \
+        openssl
 
 #install packages 
 RUN apt-get update && apt-get install -y \

--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
         libjpeg62-turbo-dev \
         libpng12-dev \
         libssl1.0.0 \
+        openssl \
         mysql-client \
         nano \
         python \

--- a/images/apache/Dockerfile.b2d
+++ b/images/apache/Dockerfile.b2d
@@ -1,14 +1,20 @@
-FROM php:5.6.17-apache
+FROM php:5.6.31-apache
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
+
+#add dependent packages
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
+RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
+RUN rm /tmp/jessie-backports.list
+
+#install libssl
+RUN apt-get update && apt-get install -y -t jessie-backports libssl1.0.0
 
 #install packages 
 RUN apt-get update && apt-get install -y \
         cron \
         libjpeg62-turbo-dev \
         libpng12-dev \
-        libssl1.0.0 \
-        openssl \
         mysql-client \
         nano \
         python \
@@ -18,9 +24,6 @@ RUN apt-get update && apt-get install -y \
         wget \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
-
-#upgrade old packages
-RUN apt-get upgrade -y
 
 #configure server
 RUN docker-php-ext-install mysqli \

--- a/images/apache/Dockerfile.b2d
+++ b/images/apache/Dockerfile.b2d
@@ -2,18 +2,10 @@ FROM php:5.6.31-apache
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
-#add dependent packages
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
-RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
-RUN rm /tmp/jessie-backports.list
-
-#install libssl and openssl
-RUN apt-get update && apt-get install -y -t jessie-backports \
-        libssl1.0.0 \
-        openssl
-
 #install packages 
-RUN apt-get update && apt-get install -y \
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y \
         cron \
         libjpeg62-turbo-dev \
         libpng12-dev \
@@ -24,6 +16,7 @@ RUN apt-get update && apt-get install -y \
         supervisor \
         vim-tiny \
         wget \
+    && apt-get install -y -t jessie-backports openssl \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
 

--- a/images/apache/Dockerfile.b2d
+++ b/images/apache/Dockerfile.b2d
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install -y \
     && wget https://git.io/psysh -O /usr/bin/psysh \
     && chmod +x /usr/bin/psysh
 
+#upgrade old packages
+RUN apt-get upgrade -y
+
 #configure server
 RUN docker-php-ext-install mysqli \
     && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \

--- a/images/apache/Dockerfile.b2d
+++ b/images/apache/Dockerfile.b2d
@@ -7,8 +7,10 @@ RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-b
 RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
 RUN rm /tmp/jessie-backports.list
 
-#install libssl
-RUN apt-get update && apt-get install -y -t jessie-backports libssl1.0.0
+#install libssl and openssl
+RUN apt-get update && apt-get install -y -t jessie-backports \
+        libssl1.0.0 \
+        openssl
 
 #install packages 
 RUN apt-get update && apt-get install -y \

--- a/images/apache/Dockerfile.b2d
+++ b/images/apache/Dockerfile.b2d
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
         libjpeg62-turbo-dev \
         libpng12-dev \
         libssl1.0.0 \
+        openssl \
         mysql-client \
         nano \
         python \

--- a/images/makeproject/Dockerfile
+++ b/images/makeproject/Dockerfile
@@ -2,6 +2,16 @@ FROM debian:jessie
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
+#add dependent packages
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
+RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
+RUN rm /tmp/jessie-backports.list
+
+#install libssl and openssl
+RUN apt-get update && apt-get install -y -t jessie-backports \
+        libssl-dev \
+        openssl
+
 # install necessary packages
 RUN apt-get update && apt-get install -y \
         curl \
@@ -9,7 +19,6 @@ RUN apt-get update && apt-get install -y \
         git \
         libcurl4-gnutls-dev \
         libmysqlclient-dev \
-        libssl-dev \
         m4 \
         make \
         php5-cli \
@@ -17,7 +26,6 @@ RUN apt-get update && apt-get install -y \
         pkg-config \
         python \
         python-mysqldb
-
 
 # get source and compile server
 COPY boinc /root/boinc

--- a/images/makeproject/Dockerfile
+++ b/images/makeproject/Dockerfile
@@ -2,18 +2,10 @@ FROM debian:jessie
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
-#add dependent packages
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
-RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
-RUN rm /tmp/jessie-backports.list
-
-#install libssl and openssl
-RUN apt-get update && apt-get install -y -t jessie-backports \
-        libssl-dev \
-        openssl
-
 # install necessary packages
-RUN apt-get update && apt-get install -y \
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y \
         curl \
         dh-autoreconf \
         git \
@@ -25,7 +17,9 @@ RUN apt-get update && apt-get install -y \
         php5-mysql \
         pkg-config \
         python \
-        python-mysqldb
+        python-mysqldb \
+    && apt-get install -y -t jessie-backports libssl-dev
+        
 
 # get source and compile server
 COPY boinc /root/boinc

--- a/images/makeproject/Dockerfile.b2d
+++ b/images/makeproject/Dockerfile.b2d
@@ -2,18 +2,10 @@ FROM debian:jessie
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
-#add dependent packages
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
-RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
-RUN rm /tmp/jessie-backports.list
-
-#install libssl and openssl
-RUN apt-get update && apt-get install -y -t jessie-backports \
-        libssl-dev \
-        openssl
-
 # install necessary packages
-RUN apt-get update && apt-get install -y \
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y \
         curl \
         dh-autoreconf \
         git \
@@ -27,7 +19,8 @@ RUN apt-get update && apt-get install -y \
         python \
         python-mysqldb \
         python-yaml \
-        wget
+        wget \
+    && apt-get install -y -t jessie-backports libssl-dev
 
 
 # get source and compile server

--- a/images/makeproject/Dockerfile.b2d
+++ b/images/makeproject/Dockerfile.b2d
@@ -2,6 +2,16 @@ FROM debian:jessie
 
 MAINTAINER Marius Millea <mariusmillea@gmail.com>
 
+#add dependent packages
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >/tmp/jessie-backports.list
+RUN cp /tmp/jessie-backports.list /etc/apt/sources.list.d/
+RUN rm /tmp/jessie-backports.list
+
+#install libssl and openssl
+RUN apt-get update && apt-get install -y -t jessie-backports \
+        libssl-dev \
+        openssl
+
 # install necessary packages
 RUN apt-get update && apt-get install -y \
         curl \
@@ -9,7 +19,6 @@ RUN apt-get update && apt-get install -y \
         git \
         libcurl4-gnutls-dev \
         libmysqlclient-dev \
-        libssl-dev \
         m4 \
         make \
         php5-cli \

--- a/images/mysql/Dockerfile
+++ b/images/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.7.10
+FROM mysql:5.7.19
 
 COPY my.cnf /etc/mysql/conf.d/my.cnf


### PR DESCRIPTION
This could likely be made redundant by switching to a newer parent docker repo, but it's worthwhile attempting to upgrade especially if new project admins don't delve much into maintaining the apache container via bash.

Related to: https://github.com/marius311/boinc-server-docker/issues/26#issuecomment-330553493