### PR TITLE
Add recursive flag to git clone for also clone submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are looking to create a server and are already somewhat familiar with Doc
 
 To check out this repository and get a test server fully up and running, simply run,
 ```bash
-git clone https://github.com/marius311/boinc-server-docker.git
+git clone --recursive https://github.com/marius311/boinc-server-docker.git
 cd boinc-server-docker
 docker-compose pull
 docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are looking to create a server and are already somewhat familiar with Doc
 
 To check out this repository and get a test server fully up and running, simply run,
 ```bash
-git clone --recursive https://github.com/marius311/boinc-server-docker.git
+git clone https://github.com/marius311/boinc-server-docker.git
 cd boinc-server-docker
 docker-compose pull
 docker-compose up -d
@@ -83,6 +83,14 @@ Finally, `boinc-server-docker` is not just useful to get a simple test server ru
 
 Happy crunching! 
 
+## Development and Contributing
+
+For using `boinc-server-docker` to work on development of the BOINC server source code, see the [development workflow](docs/dev-workflow.md). 
+
+There is developer documentation for `boinc-server-docker` itself, but please feel free to contact the maintainers or submit Issues and Pull Requests for this repository. 
+
+As a reminder, **to modify and rebuild any of the `boinc-server-docker` images, you will need this git repository's submodules checked out** (run `git submodule update --init --recursive`, or clone with `git clone --recursive` in the first place). Note also that currently building the images only works on Linux. 
+
 
 ## News
 
@@ -129,12 +137,3 @@ Happy crunching!
     * The default server URL is now `http://127.0.0.1/boincserver` rather than previously when it was `http://boincserver.com/boincserver`. This removes the need to edit your `/etc/hosts` file on Linux, and on Windows/Mac/docker-machine replaces having to edit `/etc/hosts` with the SSH tunnel command above. *Related warning: the boincserver.com domain is currently being squatted, so if you're using the old version be careful that you do not type sensitive information into the server website thinking you're interacting with your local test server when in fact it's a remote server at the squatted domain.*
     * Updated docker-compose requirement from 1.6.0 to 1.7.0, and on Windows/Mac, updated Docker Toolbox requirement from 1.10.0 to 1.11.0
     * A number of improvements to boinc2docker (see [ccfe9a9](https://github.com/marius311/boinc-server-docker/commit/ccfe9a9704b9282f528565c74e07ee3be698aa0d)).
-
-
-## Development and Contributing
-
-For using `boinc-server-docker` to work on development of the BOINC server source code, see the [development workflow](docs/dev-workflow.md). 
-
-There is developer documentation for `boinc-server-docker` itself, but please feel free to contact the maintainers or submit Issues and Pull Requests for this repository. 
-
-As a reminder, to modify and rebuild any of the `boinc-server-docker` images, you will need this git repository's submodules checked out (run `git submodule update --init --recursive`, or clone with `git clone --recursive` in the first place). Note also that currently building the images only works on Linux. 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Finally, `boinc-server-docker` is not just useful to get a simple test server ru
 
 Happy crunching! 
 
-## Development and Contributing
+### Development and Contributing
 
-For using `boinc-server-docker` to work on development of the BOINC server source code, see the [development workflow](docs/dev-workflow.md). 
+If you wish to modify and rebuild any of the `boinc-server-docker` images yourself, you will need this git repository's submodules checked out. To do so, run `git submodule update --init --recursive` from the repository folder, or clone with `git clone --recursive` in the first place. Note that building these images is only necessary if you are helping with development of this package; if you wish to build your own project _using_ these base images, follow the instruction in the [cookbook](docs/cookbook.md#creating-your-own-project) instead. 
 
-There is developer documentation for `boinc-server-docker` itself, but please feel free to contact the maintainers or submit Issues and Pull Requests for this repository. 
+Currently, building the images is only guaranteed to work on Linux. Some users have reported successfully building on Windows or Mac, but this is considered experimental at this point. 
 
-As a reminder, **to modify and rebuild any of the `boinc-server-docker` images, you will need this git repository's submodules checked out** (run `git submodule update --init --recursive`, or clone with `git clone --recursive` in the first place). Note also that currently building the images only works on Linux. 
+Please feel free to contact the maintainers or submit Issues and Pull Requests for this repository if you wish to contribute! 
 
 
 ## News


### PR DESCRIPTION
When i try to run
`git clone https://github.com/marius311/boinc-server-docker.git`
with git 2.17.0 on windows, he clones only root repo without submodules, so when i run next step
`docker-compose up -d`
its fails with `/bin/sh: 1: ./_autosetup: not found` because of `images/makeproject/boinc directory` is empty.
So i just want to save future developers from this errors